### PR TITLE
MAINT: update PyQt dependency

### DIFF
--- a/ci/conda_requirements.txt
+++ b/ci/conda_requirements.txt
@@ -9,4 +9,5 @@ seaborn
 pandas
 markdown2
 networkx
-setuptools < 20.5.0 
+setuptools < 20.5.0
+PyQt < 5.0.0


### PR DESCRIPTION
`PyQt5` is not backwards compatible with `PyQt4`.
